### PR TITLE
Surface HTTP errors in HttpClient methods

### DIFF
--- a/shared/common/src/http_client.rs
+++ b/shared/common/src/http_client.rs
@@ -25,6 +25,7 @@ impl HttpClient {
             .get(url)
             .send()
             .await?
+            .error_for_status()?
             .json::<T>()
             .await
     }
@@ -39,6 +40,7 @@ impl HttpClient {
             .json(body)
             .send()
             .await?
+            .error_for_status()?
             .json::<U>()
             .await
     }
@@ -53,15 +55,13 @@ impl HttpClient {
             .json(body)
             .send()
             .await?
+            .error_for_status()?
             .json::<U>()
             .await
     }
 
     pub async fn delete(&self, url: &str) -> Result<(), reqwest::Error> {
-        self.client
-            .delete(url)
-            .send()
-            .await?;
+        self.client.delete(url).send().await?.error_for_status()?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- ensure HTTP client methods call `error_for_status` so non-success responses bubble up

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6895d1165c688328965c4deaf7342f77